### PR TITLE
Add stub login modal

### DIFF
--- a/web/client/src/App.js
+++ b/web/client/src/App.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import './App.scss';
 import Dashboard from './content/Dashboard';
+import Login from './content/Login';
+import AppContext, { useAppContext } from './context/app';
 
 function App() {
-  return <Dashboard />;
+  return <AppContext.Provider value={useAppContext()}>
+    <Dashboard />
+    <Login />
+  </AppContext.Provider>
 }
 
 export default App;

--- a/web/client/src/App.scss
+++ b/web/client/src/App.scss
@@ -6,5 +6,6 @@ $small: 672px;
 @import 'carbon-components/scss/globals/scss/vars.scss';
 
 @import './content/Dashboard/Dashboard.scss';
+@import './content/Login/Login.scss';
 @import './components/SideMenu/SideMenu.scss';
 @import './components/Tile/Tile.scss';

--- a/web/client/src/content/Login/Login.scss
+++ b/web/client/src/content/Login/Login.scss
@@ -1,0 +1,11 @@
+.login {
+  button.bx--btn--primary {
+    flex-basis: 100%;
+  }
+  button.bx--btn--secondary {
+    display: none;
+  }
+  button.bx--modal-close {
+    display: none;
+  }
+}

--- a/web/client/src/content/Login/Login.scss
+++ b/web/client/src/content/Login/Login.scss
@@ -1,10 +1,4 @@
 .login {
-  button.bx--btn--primary {
-    flex-basis: 100%;
-  }
-  button.bx--btn--secondary {
-    display: none;
-  }
   button.bx--modal-close {
     display: none;
   }

--- a/web/client/src/content/Login/index.js
+++ b/web/client/src/content/Login/index.js
@@ -1,0 +1,40 @@
+import React, { useContext, useState } from 'react';
+import { Modal, TextInput } from 'carbon-components-react';
+import AppContext from '../../context/app';
+
+function Login() {
+  const { currentUser, setCurrentUser } = useContext(AppContext)
+  const [model, setModel] = useState(currentUser)
+
+  const handleChange = (field, { value }) =>
+    setModel(model => ({ ...model, [field]: value }))
+
+  return (
+    <div className="login">
+      <Modal
+        open={!currentUser.authenticated}
+        primaryButtonText="Login"
+        modalLabel="Welcome to OpenEEW Network Monitoring!"
+        modalHeading="Please sign in to continue"
+        shouldSubmitOnEnter={true}
+        size="xs"
+        // TODO: actually authenticate the user against something on submit
+        onRequestSubmit={() => setCurrentUser({ ...model, password: null, authenticated: true })}
+      >
+        <TextInput
+          invalidText="Invalid error message."
+          id="username"
+          labelText="Username"
+          onChange={event => handleChange('username', event.target)}
+        />
+        <TextInput.PasswordInput
+          id="password"
+          labelText="Password"
+          onChange={event => handleChange('password', event.target)}
+        />
+      </Modal>
+    </div>
+  );
+}
+
+export default Login;

--- a/web/client/src/content/Login/index.js
+++ b/web/client/src/content/Login/index.js
@@ -1,14 +1,31 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useMemo, useEffect, useState } from 'react';
 import { Modal, TextInput } from 'carbon-components-react';
 import AppContext from '../../context/app';
 
 function Login() {
   const { currentUser, setCurrentUser } = useContext(AppContext)
   const [model, setModel] = useState(currentUser)
+  const [errors, setErrors] = useState({})
+  const [submitting, setSubmitting] = useState(false)
   const [isNewUser, setIsNewUser] = useState(true)
+  const isValid = useMemo(() => (
+    !Object.values(errors).some(invalid => invalid)
+  ), [errors])
 
-  const handleChange = (field, { value }) =>
+  const handleChange = (field, { value }) => {
+    setErrors({})
     setModel(model => ({ ...model, [field]: value }))
+  }
+
+  useEffect(() => {
+    if (!submitting) { return }
+
+    if (isValid) {
+      // TODO: actually authenticate the user against something on submit
+      setCurrentUser({ ...model, password: null, confirmPassword: null, authenticated: true })
+    }
+    setSubmitting(false)
+  }, [submitting, isValid, model, setCurrentUser])
 
   return (
     <div className="login">
@@ -20,32 +37,48 @@ function Login() {
         modalHeading={isNewUser ? 'Create an account' : 'Please sign in to continue'}
         shouldSubmitOnEnter={true}
         size="sm"
-        onSecondarySubmit={() => setIsNewUser(!isNewUser)}
-        // TODO: actually authenticate the user against something on submit
-        onRequestSubmit={() => setCurrentUser({ ...model, password: null, authenticated: true })}
+        onSecondarySubmit={() => {
+          setErrors({})
+          setIsNewUser(!isNewUser)
+        }}
+        onRequestSubmit={() => {
+          setErrors({
+            name: isNewUser && model.name.length === 0,
+            email: model.email.length === 0,
+            password: model.password.length === 0,
+            confirmPassword: isNewUser && model.password !== model.confirmPassword
+          })
+          setSubmitting(true)
+        }}
       >
         {isNewUser && <TextInput
-          invalidText="Invalid error message."
           id="name"
           labelText="Name"
+          invalid={errors.name}
+          invalidText="Name must be present"
           onChange={event => handleChange('name', event.target)}
         />}
         <TextInput
-          invalidText="Invalid error message."
           id="email"
           type="email"
           labelText="Email"
+          invalid={errors.email}
+          invalidText="Email must be present"
           onChange={event => handleChange('email', event.target)}
         />
         <TextInput.PasswordInput
           id="password"
           labelText="Password"
+          invalid={errors.password}
+          invalidText="Password must be present"
           onChange={event => handleChange('password', event.target)}
         />
         {isNewUser && <TextInput.PasswordInput
           id="confirmPassword"
           labelText="Confirm Password"
-          onChange={event => handleChange('password', event.target)}
+          invalid={errors.confirmPassword}
+          invalidText="Passwords must match"
+          onChange={event => handleChange('confirmPassword', event.target)}
         />}
       </Modal>
     </div>

--- a/web/client/src/content/Login/index.js
+++ b/web/client/src/content/Login/index.js
@@ -5,6 +5,7 @@ import AppContext from '../../context/app';
 function Login() {
   const { currentUser, setCurrentUser } = useContext(AppContext)
   const [model, setModel] = useState(currentUser)
+  const [isNewUser, setIsNewUser] = useState(true)
 
   const handleChange = (field, { value }) =>
     setModel(model => ({ ...model, [field]: value }))
@@ -13,25 +14,39 @@ function Login() {
     <div className="login">
       <Modal
         open={!currentUser.authenticated}
-        primaryButtonText="Login"
+        primaryButtonText={isNewUser ? 'Sign Up' : 'Log In'}
+        secondaryButtonText={isNewUser ? 'Use existing account' : 'Create an account'}
         modalLabel="Welcome to OpenEEW Network Monitoring!"
-        modalHeading="Please sign in to continue"
+        modalHeading={isNewUser ? 'Create an account' : 'Please sign in to continue'}
         shouldSubmitOnEnter={true}
-        size="xs"
+        size="sm"
+        onSecondarySubmit={() => setIsNewUser(!isNewUser)}
         // TODO: actually authenticate the user against something on submit
         onRequestSubmit={() => setCurrentUser({ ...model, password: null, authenticated: true })}
       >
+        {isNewUser && <TextInput
+          invalidText="Invalid error message."
+          id="name"
+          labelText="Name"
+          onChange={event => handleChange('name', event.target)}
+        />}
         <TextInput
           invalidText="Invalid error message."
-          id="username"
-          labelText="Username"
-          onChange={event => handleChange('username', event.target)}
+          id="email"
+          type="email"
+          labelText="Email"
+          onChange={event => handleChange('email', event.target)}
         />
         <TextInput.PasswordInput
           id="password"
           labelText="Password"
           onChange={event => handleChange('password', event.target)}
         />
+        {isNewUser && <TextInput.PasswordInput
+          id="confirmPassword"
+          labelText="Confirm Password"
+          onChange={event => handleChange('password', event.target)}
+        />}
       </Modal>
     </div>
   );

--- a/web/client/src/context/app.js
+++ b/web/client/src/context/app.js
@@ -3,7 +3,12 @@ import { createContext, useState } from 'react';
 export default createContext({});
 
 export const useAppContext = () => {
-  const [currentUser, setCurrentUser] = useState({})
+  const [currentUser, setCurrentUser] = useState({
+    name: '',
+    email: '',
+    password: '',
+    confirmPassword: ''
+  })
 
   return {
     currentUser, setCurrentUser

--- a/web/client/src/context/app.js
+++ b/web/client/src/context/app.js
@@ -1,0 +1,11 @@
+import { createContext, useState } from 'react';
+
+export default createContext({});
+
+export const useAppContext = () => {
+  const [currentUser, setCurrentUser] = useState({})
+
+  return {
+    currentUser, setCurrentUser
+  }
+}


### PR DESCRIPTION
This adds a login modal that we can (later) use to authenticate people who come to the dashboard.
<img width="671" alt="Captura de Pantalla 2020-10-18 a la(s) 1 41 34 p  m" src="https://user-images.githubusercontent.com/750477/96356193-af84d380-1147-11eb-8847-6a3ed16f2102.png">


It allows the user to switch between creating a new account and logging in with an existing one:
<img width="620" alt="Captura de Pantalla 2020-10-18 a la(s) 1 41 39 p  m" src="https://user-images.githubusercontent.com/750477/96356196-b4e21e00-1147-11eb-8e34-92c02a979b9f.png">


Currently it pops up on page load and sets a current user with the username for whatever you put in (it does not actually authenticate the user against anything or create accounts yet).

There's basic error handling too!
<img width="605" alt="Captura de Pantalla 2020-10-18 a la(s) 2 13 23 p  m" src="https://user-images.githubusercontent.com/750477/96356509-1f955880-114c-11eb-8cb7-46711e5e8b87.png">
<img width="642" alt="Captura de Pantalla 2020-10-18 a la(s) 2 13 30 p  m" src="https://user-images.githubusercontent.com/750477/96356512-22904900-114c-11eb-9327-3cca556685b2.png">


The idea behind putting this into a React Context is to make it super easy in the future to refer to the current user from whatever component you're in, e.g.:
```
import React, { useContext } from 'react'
import Context from '../context/app'

const AdminOnlyComponent = () => {
  const { currentUser } = useContext(Context)

  if (!currentUser.admin) { return null }
  
  return <div className="admin-only-component">...</div>
}

export default AdminOnlyComponent
```