### PR TITLE
Add react router; stub settings page

### DIFF
--- a/web/client/package-lock.json
+++ b/web/client/package-lock.json
@@ -3611,6 +3611,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -6609,6 +6618,12 @@
         "schema-utils": "^2.5.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -7211,6 +7226,19 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
+    },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -8548,6 +8576,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         }
@@ -10062,6 +10091,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
+    },
+    "mini-create-react-context": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
+      "integrity": "sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "tiny-warning": "^1.0.3"
+      }
     },
     "mini-css-extract-plugin": {
       "version": "0.9.0",
@@ -12613,6 +12651,52 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-scripts": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.4.3.tgz",
@@ -12998,6 +13082,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -14533,6 +14622,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -14938,6 +15037,11 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -15054,6 +15158,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -15316,6 +15421,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/web/client/package.json
+++ b/web/client/package.json
@@ -28,6 +28,7 @@
     "react-apollo": "^3.1.5",
     "react-app-polyfill": "^1.0.6",
     "react-dom": "^16.13.1",
+    "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.3",
     "typescript": "^4.0.2"
   },

--- a/web/client/src/App.js
+++ b/web/client/src/App.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import './App.scss';
-import Dashboard from './content/Dashboard';
-import Login from './content/Login';
+import Router from './Router';
 import AppContext, { useAppContext } from './context/app';
 
 function App() {
   return <AppContext.Provider value={useAppContext()}>
-    <Dashboard />
-    <Login />
+    <Router />
   </AppContext.Provider>
 }
 

--- a/web/client/src/Router.js
+++ b/web/client/src/Router.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { BrowserRouter, Switch, Route } from 'react-router-dom';
+import Dashboard from './content/Dashboard';
+import AccountSettings from './content/AccountSettings';
+import Header from './components/Header';
+import SideMenu from './components/SideMenu';
+import Login from './content/Login';
+
+function Router() {
+  return (
+    <BrowserRouter>
+      <Login />
+      <Header />
+      <SideMenu />
+      <div className="app-content">
+        <Switch>
+          <Route path="/settings">
+            <AccountSettings />
+          </Route>
+          <Route path="/">
+            <Dashboard />
+          </Route>
+        </Switch>
+      </div>
+    </BrowserRouter>
+  );
+}
+
+export default Router;

--- a/web/client/src/components/Header/Header.js
+++ b/web/client/src/components/Header/Header.js
@@ -1,21 +1,21 @@
 import React from "react";
 import {
   Header,
-  HeaderName,
   HeaderNavigation,
   HeaderGlobalBar,
   HeaderGlobalAction,
   SkipToContent,
 } from "carbon-components-react/lib/components/UIShell";
+import { Link } from "react-router-dom";
 import Notification20 from "@carbon/icons-react/lib/notification/20";
 import UserAvatar20 from "@carbon/icons-react/lib/user--avatar/20";
 
 const TutorialHeader = () => (
   <Header aria-label="Open EEW Network Monitoring">
     <SkipToContent />
-    <HeaderName href="/" prefix="OpenEEW">
-      Network Monitoring
-    </HeaderName>
+    <Link to="/" className="bx--header__name">
+      OpenEEW Network Monitoring
+    </Link>
     <HeaderNavigation aria-label="Open EEW Network Monitoring">
       {/* Nav items go here */}
     </HeaderNavigation>
@@ -23,9 +23,11 @@ const TutorialHeader = () => (
       <HeaderGlobalAction aria-label="Notifications">
         <Notification20 />
       </HeaderGlobalAction>
-      <HeaderGlobalAction aria-label="User Avatar">
-        <UserAvatar20 />
-      </HeaderGlobalAction>
+      <Link to="/settings">
+        <HeaderGlobalAction aria-label="User Avatar">
+          <UserAvatar20 />
+        </HeaderGlobalAction>
+      </Link>
     </HeaderGlobalBar>
   </Header>
 );

--- a/web/client/src/content/AccountSettings/index.js
+++ b/web/client/src/content/AccountSettings/index.js
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import Context from '../../context/app';
 
 function AccountSettings() {
+  const { currentUser } = useContext(Context);
+
   return (
-    <div>WARK</div>
+    <div>Welcome {currentUser.name}!</div>
   );
 }
 

--- a/web/client/src/content/AccountSettings/index.js
+++ b/web/client/src/content/AccountSettings/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+function AccountSettings() {
+  return (
+    <div>WARK</div>
+  );
+}
+
+export default AccountSettings;

--- a/web/client/src/content/Dashboard/Dashboard.scss
+++ b/web/client/src/content/Dashboard/Dashboard.scss
@@ -1,10 +1,3 @@
-.dashboard-content {
-  padding-top: 3rem;
-  padding-bottom: 3rem;
-  padding-left: 5rem;
-  max-width: 1600px;
-}
-
 .bx--row {
   margin-top: $layout-03;
 }

--- a/web/client/src/content/Dashboard/index.js
+++ b/web/client/src/content/Dashboard/index.js
@@ -1,13 +1,9 @@
 import React from 'react';
-import Header from '../../components/Header';
 import Sensors from './sensors';
-import SideMenu from '../../components/SideMenu';
 
 function Dashboard() {
   return (
     <div>
-      <Header />
-      <SideMenu />
       <Sensors />
     </div>
   );

--- a/web/client/src/index.scss
+++ b/web/client/src/index.scss
@@ -5,7 +5,11 @@ $carbon--theme: $carbon--theme--g90;
 
 $feature-flags: (
   ui-shell: true,
-  grid-columns-16: true,
 );
 
 @import 'carbon-components/scss/globals/scss/styles.scss';
+
+.app-content {
+  padding: $layout-05;
+  max-width: 1600px;
+}

--- a/web/client/src/index.scss
+++ b/web/client/src/index.scss
@@ -5,6 +5,7 @@ $carbon--theme: $carbon--theme--g90;
 
 $feature-flags: (
   ui-shell: true,
+  grid-columns-16: true,
 );
 
 @import 'carbon-components/scss/globals/scss/styles.scss';


### PR DESCRIPTION
This adds a basic implementation of `react-router` to allow for displaying different pages within the dashboard.

I've added a stub `/settings` route which you can visit by clicking the user icon in the top right; clicking on the 'OpenEEW Network Monitoring' link in the header will return to the dashboard.

<img width="795" alt="Captura de Pantalla 2020-10-22 a la(s) 9 16 57 p  m" src="https://user-images.githubusercontent.com/750477/96844399-f5c19600-14ab-11eb-8202-b9102b7954f6.png">
<img width="794" alt="Captura de Pantalla 2020-10-22 a la(s) 9 17 05 p  m" src="https://user-images.githubusercontent.com/750477/96844409-f823f000-14ab-11eb-91b5-9b2f2db1bb33.png">
