### PR TITLE
Adds onboarding link to API /verification response

### DIFF
--- a/web/api/.eslintrc
+++ b/web/api/.eslintrc
@@ -4,7 +4,7 @@
     "ecmaVersion": 2018,
     "sourceType": "module"
   },
-  "env": { "node": true },
+  "env": { "node": true, "es6": true },
   "rules": {
     "object-curly-spacing": ["error", "always"],
     "space-before-function-paren": [

--- a/web/api/package.json
+++ b/web/api/package.json
@@ -17,6 +17,7 @@
     "graphql-yoga": "^1.18.3",
     "helmet": "^4.2.0",
     "ibmcloud-appid": "^6.1.1",
+    "jsonwebtoken": "^8.5.1",
     "node-fetch": "^2.6.1",
     "passport": "^0.4.1",
     "qs": "^6.9.5"

--- a/web/api/services/jwt.js
+++ b/web/api/services/jwt.js
@@ -1,0 +1,40 @@
+const jwt = require('jsonwebtoken');
+
+let secret;
+
+if (process.env.VCAP_APPLICATION) {
+  secret = process.env.JWT_SECRET;
+} else {
+  secret = require('../vcap-local.json').user_vars.jwt_secret;
+}
+
+if (!secret) {
+  throw new Error(
+    'No JWT secret found. If this is a dev environment, add required secrets to a copy of vcap-local.template.json named vcap-local.json.',
+  );
+}
+
+const encode = (payload) =>
+  new Promise((resolve, reject) => {
+    jwt.sign(payload, secret, { algorithm: 'HS256' }, function (err, token) {
+      if (err) {
+        return reject(err);
+      }
+      return resolve(token);
+    });
+  });
+
+const decode = (token) =>
+  new Promise((resolve, reject) => {
+    jwt.verify(token, secret, function (error, decoded) {
+      if (error) {
+        return reject(error);
+      }
+      return resolve(decoded);
+    });
+  });
+
+module.exports = {
+  encode,
+  decode,
+};

--- a/web/api/services/jwt.js
+++ b/web/api/services/jwt.js
@@ -16,20 +16,18 @@ if (!secret) {
 
 const encode = (payload) =>
   new Promise((resolve, reject) => {
-    jwt.sign(payload, secret, { algorithm: 'HS256' }, function (err, token) {
-      if (err) {
-        return reject(err);
-      }
+    jwt.sign(payload, secret, { algorithm: 'HS256' }, (err, token) => {
+      if (err) return reject(err);
+
       return resolve(token);
     });
   });
 
 const decode = (token) =>
   new Promise((resolve, reject) => {
-    jwt.verify(token, secret, function (error, decoded) {
-      if (error) {
-        return reject(error);
-      }
+    jwt.verify(token, secret, (error, decoded) => {
+      if (error) return reject(error);
+
       return resolve(decoded);
     });
   });

--- a/web/api/vcap-local.template.json
+++ b/web/api/vcap-local.template.json
@@ -1,7 +1,8 @@
 {
   "user_vars": {
     "session_secret": "",
-    "openeew_api_key": ""
+    "openeew_api_key": "",
+    "jwt_secret": ""
   },
   "ibm_cloud": {
     "api_key": ""

--- a/web/manifest.template.yml
+++ b/web/manifest.template.yml
@@ -15,6 +15,10 @@ applications:
     routes:
       - route: # URL of api -- should be same domain as client, with /api added
     env:
-      SESSION_SECRET: #any random string of chars, should be rotated and kept secret
+      SESSION_SECRET: # Create a session secret. Any random string of chars, should be rotated and kept secret.
+      JWT_SECRET: # Create a secret for signing JWTs. Any random string of chars, should be rotated and kept secret.
+      ALLOWED_ORIGIN_URLS: # Allowed origins, separated by commas. First in list should be dashboard URL.
+      IAM_API_KEY: # IBM Cloud API key to make requests to AppID management API. This is obtained from IBM Cloud.
+      OPENEEW_API_KEY: # Create an API key to autheticate requests from other services.
     buildpacks:
       - https://github.com/cloudfoundry/nodejs-buildpack


### PR DESCRIPTION
For each new user (email not already in AppID when adding a sensor), a URL link is generated so that the user can finish their account creation on the dashboard. After the account is created in AppID, the new user's ID is encoded in a JWT and passed as a query parameter to the onboarding dashboard route. The front end component of this still needs to be built.