### PR TITLE
Updating prettier from 2.2.1 -> 2.3.0

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,6 +18,6 @@ jobs:
 
       - name: Set up node
         uses: actions/setup-node@v1
-      - run: npm install -g dockerfilelint prettier
+      - run: npm install -g dockerfilelint prettier@2.3.0
       - run: dockerfilelint ./web/Dockerfile
       - run: prettier --check .

--- a/web/client/package.json
+++ b/web/client/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "eslint-plugin-react-hooks": "^4.2.0",
     "husky": "^4.3.0",
-    "prettier": "^2.2.1",
+    "prettier": "^2.3.0",
     "pretty-quick": "^3.1.0"
   }
 }

--- a/web/client/package.json
+++ b/web/client/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "eslint-plugin-react-hooks": "^4.2.0",
     "husky": "^4.3.0",
-    "prettier": "^2.3.0",
+    "prettier": "2.3.0",
     "pretty-quick": "^3.1.0"
   }
 }

--- a/web/client/src/content/Onboard/index.js
+++ b/web/client/src/content/Onboard/index.js
@@ -20,8 +20,9 @@ const Onboard = ({ location }) => {
 
   useEffect(() => {
     const verifyToken = async () => {
-      const _token = qs.parse(location.search, { ignoreQueryPrefix: true })
-        .token
+      const _token = qs.parse(location.search, {
+        ignoreQueryPrefix: true,
+      }).token
 
       if (!_token) {
         setPageLoading(false)


### PR DESCRIPTION
Setting Prettier's version number on our GitHub Action and package.json. This will allow us to keep the checks synced. If we use a mismatched version, there is potential for formatting errors that are also mismatched. For example, 2.3.0 has more checks than 2.2.1, so the 2.3.0 prettier --check command can fail while 2.2.1 may pass.

The index.js file in this Pull Request was caught in the example situation.