### PR TITLE
Add warning, modify mock data

### DIFF
--- a/web/client/package-lock.json
+++ b/web/client/package-lock.json
@@ -45,7 +45,7 @@
       "devDependencies": {
         "eslint-plugin-react-hooks": "^4.2.0",
         "husky": "^4.3.0",
-        "prettier": "^2.2.1",
+        "prettier": "2.3.0",
         "pretty-quick": "^3.1.0"
       }
     },
@@ -13490,9 +13490,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -30757,9 +30757,9 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
       "dev": true
     },
     "pretty-bytes": {

--- a/web/client/src/content/Events/index.js
+++ b/web/client/src/content/Events/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import EventsMap from '../../components/EventsMap'
 import { Dropdown } from 'carbon-components-react'
 import EarthquakeList from '../../components/EarthquakeList'
@@ -7,6 +7,7 @@ import { CheckmarkFilled16 } from '@carbon/icons-react'
 import Field from '../../components/Field'
 import { earthquakes, takeEventsMapSnapshot } from '../../context/app'
 import { formatCoordinates, formatDate, formatTime } from '../../utils'
+import AppContext from '../../context/app'
 
 const dayInSeconds = 86400
 
@@ -38,6 +39,16 @@ const Events = () => {
   const [selectedTimeFilter, setSelectedTimeFilter] = useState(
     items[defaultTimeFilterIndex]
   )
+  const { addToast } = useContext(AppContext)
+
+  useEffect(() => {
+    addToast({
+      kind: 'warning',
+      caption:
+        'The dashboard is a work in progress. In the near future, this page will show events detected by OpenEEW regional networks. Currently, this page uses mock data to demonstrate its features.',
+      title: 'Note: This data is not real, but will be soon!',
+    })
+  }, [])
 
   return (
     <div className="events-page">
@@ -71,10 +82,6 @@ const Events = () => {
             <div>
               <h4>{earthquakes.length}</h4>
               <span>Earthquakes detected</span>
-            </div>
-            <div>
-              <h4>2,400</h4>
-              <span>Subscribers alerted</span>
             </div>
           </div>
           <div className="events-page-earthquake-list__container">

--- a/web/client/src/context/app.js
+++ b/web/client/src/context/app.js
@@ -8,7 +8,7 @@ export const earthquakes = [
   {
     pos: [-104.3533, 20.65],
     magnitude: 1,
-    locationText: 'Lorem ipsum dolor',
+    locationText: 'Sample Event Lorem ipsum',
     country: 'Mexico',
     date: new Date().getTime(),
     alertDelay: 1,
@@ -16,7 +16,7 @@ export const earthquakes = [
   {
     pos: [-99.3533, 20.65],
     magnitude: 2,
-    locationText: 'Lorem ipsum dolor',
+    locationText: 'Sample Event Lorem dolor',
     country: 'Mexico',
     date: new Date().getTime() - 86400 * 7 * 1000,
     alertDelay: 5,
@@ -24,7 +24,7 @@ export const earthquakes = [
   {
     pos: [-102.3533, 25.65],
     magnitude: 3,
-    locationText: 'Lorem ipsum dolor',
+    locationText: 'Sample Event Lorem',
     country: 'Mexico',
     date: new Date().getTime() - 86400 * 30 * 1000,
     alertDelay: 3,
@@ -32,7 +32,7 @@ export const earthquakes = [
   {
     pos: [-96.01, 16.01],
     magnitude: 4,
-    locationText: 'Lorem ipsum dolor',
+    locationText: 'Sample Lorem ipsum dolor',
     country: 'Mexico',
     date: new Date().getTime() - 86400 * 90 * 1000,
     alertDelay: 4,

--- a/web/client/src/context/app.js
+++ b/web/client/src/context/app.js
@@ -8,7 +8,7 @@ export const earthquakes = [
   {
     pos: [-104.3533, 20.65],
     magnitude: 1,
-    locationText: '3km South of Blah Blah town',
+    locationText: 'Lorem ipsum dolor',
     country: 'Mexico',
     date: new Date().getTime(),
     alertDelay: 1,
@@ -16,7 +16,7 @@ export const earthquakes = [
   {
     pos: [-99.3533, 20.65],
     magnitude: 2,
-    locationText: '15km South of Yadayada town',
+    locationText: 'Lorem ipsum dolor',
     country: 'Mexico',
     date: new Date().getTime() - 86400 * 7 * 1000,
     alertDelay: 5,
@@ -24,7 +24,7 @@ export const earthquakes = [
   {
     pos: [-102.3533, 25.65],
     magnitude: 3,
-    locationText: '3km South of Lorem Ipsum',
+    locationText: 'Lorem ipsum dolor',
     country: 'Mexico',
     date: new Date().getTime() - 86400 * 30 * 1000,
     alertDelay: 3,
@@ -32,7 +32,7 @@ export const earthquakes = [
   {
     pos: [-96.01, 16.01],
     magnitude: 4,
-    locationText: '3km East of Mexico City',
+    locationText: 'Lorem ipsum dolor',
     country: 'Mexico',
     date: new Date().getTime() - 86400 * 90 * 1000,
     alertDelay: 4,
@@ -40,7 +40,7 @@ export const earthquakes = [
   {
     pos: [-108.01, 28.01],
     magnitude: 5,
-    locationText: '3km East of Some Random Town',
+    locationText: 'Lorem ipsum dolor',
     country: 'Mexico',
     date: new Date().getTime() - 86400 * 365 * 1000,
     alertDelay: 5,


### PR DESCRIPTION
In lieu of showing live data on the site, this adds a warning to the events page that makes it clear that the data shown is not currently accurate.

![image](https://user-images.githubusercontent.com/1787025/119475454-05cf7b80-bd02-11eb-82fc-f6b922d78a85.png)
