### PR TITLE
chore: disable false positive lint warning

### DIFF
--- a/web/client/src/content/Events/index.js
+++ b/web/client/src/content/Events/index.js
@@ -48,7 +48,7 @@ const Events = () => {
         'The dashboard is a work in progress. In the near future, this page will show events detected by OpenEEW regional networks. Currently, this page uses mock data to demonstrate its features.',
       title: 'Note: This data is not real, but will be soon!',
     })
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className="events-page">


### PR DESCRIPTION
ESLint was surfacing the following error in `Events/index.js`:

`React Hook useEffect has a missing dependency: 'addToast'. Either include it or remove the dependency array`

As `addToast` should only run once, the dependency array should remain empty — this PR ignores the lint warning.